### PR TITLE
OS-596: fix remarkable fail  for fusion

### DIFF
--- a/remarkable-fail.sh
+++ b/remarkable-fail.sh
@@ -35,6 +35,8 @@ if [[ -n "$LASTCRASHTIME" ]]; then
         rm -f /tmp/lastcrashtime
         exit 0
     fi
+else
+    LASTCHRASHTIME=${CURRENTTIME}
 fi
 
 echo "$CURRENTTIME" > /tmp/lastcrashtime

--- a/remarkable-fail.sh
+++ b/remarkable-fail.sh
@@ -78,7 +78,7 @@ fi
 # so try to get an update.
 
 echo "Trying to bring up wifi"
-echo 0 > /sys/class/rfkill/rfkill0/soft
+echo 0 > /sys/class/rfkill/rfkill*/soft
 
 systemctl enable dhcpcd
 systemctl start dhcpcd

--- a/remarkable-fail.sh
+++ b/remarkable-fail.sh
@@ -7,9 +7,15 @@ set +o noclobber
 
 flock -n 123
 
-CRASHNUM="$(cat /tmp/crashnum)"
-CRASHNUM="$((CRASHNUM + 1))"
-echo "$CRASHNUM" > /tmp/crashnum
+# Read/create /tmp/crashnum and increment it
+CRASHNUM=
+if [[ -w /tmp/crashnum ]]; then
+    CRASHNUM="$(cat /tmp/crashnum)"
+    CRASHNUM="$((${CRASHNUM} + 1))"
+else
+    CRASHNUM=1
+fi
+echo "${CRASHNUM}" > /tmp/crashnum
 
 echo "We've crashed $CRASHNUM times"
 


### PR DESCRIPTION
[OS-596](https://getremarkable.atlassian.net/browse/OS-569):
* rfkill path updated with wildcard 
* Set `LASTCRASHTIME` if empty as it is used later in the script regardless
* Minor refactor to avoid "file not found" error messages